### PR TITLE
Update server info

### DIFF
--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -398,8 +398,8 @@ export class EngineState {
         onGoodMessage: (uri: string, latency: number) => {
           this.pluginState.updateServerInfo({ uri, latency, goodMessages: 1 })
         },
-        onBadMessage: (uri: string, latency: number) => {
-          this.pluginState.updateServerInfo({ uri, latency, badMessages: 1 })
+        onBadMessage: (uri: string) => {
+          this.pluginState.updateServerInfo({ uri, badMessages: 1 })
         },
         onQueueSpace: uri => {
           const start = Date.now()

--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -385,29 +385,22 @@ export class EngineState {
 
       const callbacks: StratumCallbacks = {
         onOpen: (uri: string) => this.log(`Connected to ${uri}`),
-        onClose: (
-          uri: string,
-          badMessages: number,
-          goodMessages: number,
-          latency: number,
-          hadError: boolean
-        ) => {
+        onClose: (uri: string, hadError: boolean) => {
           delete this.connections[uri]
-          this.pluginState.serverDisconnected(
-            uri,
-            badMessages,
-            hadError,
-            goodMessages,
-            latency
-          )
+          this.pluginState.updateServerInfo({ uri, disconnects: 1 })
           if (this.engineStarted) {
             this.reconnectTimer = setTimeout(() => this.refillServers(),
-              goodMessages ? 0 : KEEPALIVE_MS)
+              hadError ? KEEPALIVE_MS : 0)
           }
-          this.addressCacheDirty && this.saveAddressCache()
-          this.txCacheDirty && this.saveTxCache()
+          this.saveAddressCache()
+          this.saveTxCache()
         },
-
+        onGoodMessage: (uri: string, latency: number) => {
+          this.pluginState.updateServerInfo({ uri, latency, goodMessages: 1 })
+        },
+        onBadMessage: (uri: string, latency: number) => {
+          this.pluginState.updateServerInfo({ uri, latency, badMessages: 1 })
+        },
         onQueueSpace: uri => {
           const start = Date.now()
           const task = this.pickNextTask(uri)

--- a/src/plugin/pluginState.js
+++ b/src/plugin/pluginState.js
@@ -10,6 +10,14 @@ export interface ServerInfo {
   version: string; // Server version
 }
 
+export type NewServerInfo = {
+  uri: string;
+  badMessages?: number;
+  disconnects?: number;
+  goodMessages?: number;
+  latency?: number;
+}
+
 export const TIME_LAZINESS = 10000
 
 /**
@@ -261,24 +269,20 @@ export class PluginState {
     }
   }
 
-  serverDisconnected (
-    uri: string,
-    badMessages: number,
-    disconnected: boolean,
-    goodMessages: number,
-    latency: number
-  ) {
+  updateServerInfo ({
+    uri,
+    latency = 0,
+    badMessages = 0,
+    goodMessages = 0,
+    disconnects = 0
+  }: NewServerInfo) {
     this.serverCache[uri].badMessages += badMessages
-    this.serverCache[uri].disconnects += disconnected ? 1 : 0
     this.serverCache[uri].goodMessages += goodMessages
-    if (latency > 0) this.serverCache[uri].latency = latency
+    this.serverCache[uri].disconnects += disconnects
+    if (latency > 0) {
+      this.serverCache[uri].latency += (this.serverCache[uri].latency + latency) / 2
+    }
     this.dirtyServerCache()
-    if (this.headerCacheDirty) {
-      this.saveHeaderCache()
-    }
-    if (this.serverCacheDirty) {
-      this.saveServerCache()
-    }
   }
 
   updateHeight (height: number) {

--- a/src/plugin/pluginState.js
+++ b/src/plugin/pluginState.js
@@ -280,7 +280,7 @@ export class PluginState {
     this.serverCache[uri].goodMessages += goodMessages
     this.serverCache[uri].disconnects += disconnects
     if (latency > 0) {
-      this.serverCache[uri].latency += (this.serverCache[uri].latency + latency) / 2
+      this.serverCache[uri].latency = (this.serverCache[uri].latency + latency) / 2
     }
     this.dirtyServerCache()
   }

--- a/src/plugin/pluginState.js
+++ b/src/plugin/pluginState.js
@@ -30,10 +30,8 @@ function scoreServer (info: ServerInfo) {
   // We give every server 1 failure and 1 success to start:
   const failures = 1 + info.badMessages + 2 * info.disconnects
   const successes = 1 + info.goodMessages
-  // If a server has zero latency, treat that like 1 second:
-  const latency = info.latency || 1000
 
-  return latency * failures / (failures + successes)
+  return failures / (failures + successes)
 }
 
 /**
@@ -80,7 +78,10 @@ export class PluginState {
         if (blacklistA !== blacklistB) {
           return blacklistA ? 1 : -1
         }
-        return scoreServer(infoA) - scoreServer(infoB)
+        const scoreA = scoreServer(infoA)
+        const scoreB = scoreServer(infoB)
+        if (scoreA !== scoreB) return scoreA - scoreB
+        return infoB.latency - infoA.latency
       })
   }
 

--- a/src/stratum/stratumConnection.js
+++ b/src/stratum/stratumConnection.js
@@ -50,7 +50,7 @@ export class StratumConnection {
   log: Function
 
   constructor (uri: string, options: StratumOptions, log: ?Function) {
-    const { callbacks = {}, io, queueSize = 10, timeout = 15 } = options
+    const { callbacks = {}, io, queueSize = 10, timeout = 30 } = options
     const {
       onOpen = nop,
       onClose = nop,


### PR DESCRIPTION
Currently, we only update the Server Info (Which will later be used when calculating the score) only when disconnecting from a server. 
This is a problem since if the app is not closed using the disconnect method (for example, in a crash somewhere), we would lose all the server info.

This PR goal is to update the server info (which then translates into the score) on every new information we have (good message, bad message, etc...).