### PR TITLE
BCH double balance fix

### DIFF
--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -1023,7 +1023,9 @@ export class EngineState extends EventEmitter {
 
     // Make a list of unconfirmed transactions for the utxo search:
     const pendingTxids = txids.filter(
-      txid => this.txHeightCache[txid].height <= 0
+      txid =>
+        this.txHeightCache[txid].height <= 0 &&
+        !utxos.find(utxo => utxo.txid === txid)
     )
 
     // Add all our own unconfirmed outpoints to the utxo list:


### PR DESCRIPTION
Some electrum servers do return unconfirmed UTXO's so filter those from the pendingTxids list
 
Asana task: https://app.asana.com/0/361770107085503/565600412505649/f