### PR TITLE
Prevent throw when wallet has an OP_RETURN transaction output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## 2.14.12-pending
 
+* Add Zcoin support
 * Fix throw in getTransaction when tx has an OP_RETURN
+
+## 2.14.11
+
+* Filter uncofimred UTXO's the pendingTxids list for servers that return uncofimred UTXO's as part of the tx history.
+* Better caching mechanism
+* Use the "onAddressesChecked" callback to return a value between 0 and 1 for how "synced" the engine is.
+* Styling fixes
+* Flow fixes
+* Tests fixes
+
+## 2.14.10
+
+* Return Transaction date in seconds and not miliseconds
 
 ## 2.14.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # edge-currency-bitcoin
 
+## 2.14.12-pending
+
+* Fix throw in getTransaction when tx has an OP_RETURN
+
 ## 2.14.9
 
 * Fix .flowconfig to include all src files

--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -212,6 +212,9 @@ export class CurrencyEngine {
     const outputsLength = bcoinTransaction.outputs.length
     for (let i = 0; i < outputsLength; i++) {
       output = bcoinTransaction.outputs[i].getJSON(this.network)
+      if (output.address === null || output.value === 0) {
+        continue
+      }
       value = output.value
       address = toNewFormat(output.address, this.network)
       totalOutputAmount += value

--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -207,14 +207,17 @@ export class CurrencyEngine {
     let address = ''
     let value = 0
     let output = null
+    let type = null
 
     // Process tx outputs
     const outputsLength = bcoinTransaction.outputs.length
     for (let i = 0; i < outputsLength; i++) {
-      output = bcoinTransaction.outputs[i].getJSON(this.network)
-      if (output.address === null || output.value === 0) {
+      output = bcoinTransaction.outputs[i]
+      type = output.getType()
+      if (type === 'nonstandard' || type === 'nulldata') {
         continue
       }
+      output = output.getJSON(this.network)
       value = output.value
       address = toNewFormat(output.address, this.network)
       totalOutputAmount += value


### PR DESCRIPTION
Check for 0 value or null address output and skip output if so