### PR TITLE
Small connectivity fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # edge-currency-bitcoin
 
+## 2.16.3
+
+* Set the response time if serverScoreDown() is called. This prevents this server from being considered "new" and being tried again in the future at the top of the list.
+* Fix port numbers for zcoin electrum servers
+* Fix zcoin block explorer urls
+* Completely ignore electrums: urls for now
+
 ## 2.16.2
 
-* Catch errors from startum servers
+* Catch errors from stratum servers
 
 ## 2.16.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-currency-bitcoin",
-  "version": "2.16.2",
+  "version": "2.16.3",
   "description": "Edge Bitcoin currency plugin",
   "homepage": "https://edgesecure.co",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -450,7 +450,8 @@ export class EngineState extends EventEmitter {
   refillServers () {
     const { io } = this
     const ignorePatterns = []
-    if (!this.io.TLSSocket) ignorePatterns.push('electrums:')
+    // if (!this.io.TLSSocket)
+    ignorePatterns.push('electrums:')
     if (!this.io.Socket) ignorePatterns.push('electrum:')
     const servers = this.pluginState.getServers(NEW_CONNECTIONS, ignorePatterns)
     console.log(

--- a/src/info/zcoin.js
+++ b/src/info/zcoin.js
@@ -51,19 +51,19 @@ export const zcoinInfo: AbcCurrencyInfo = {
     },
     electrumServers: [
       'electrum://51.15.82.184:50001',
-      'electrums://51.15.82.184:50002',
-      'electrums://45.63.92.224:50001',
-      'electrums://45.63.92.224:50002',
+      'electrum://45.63.92.224:50001',
       'electrum://47.75.76.176:50001',
+      'electrums://51.15.82.184:50002',
+      'electrums://45.63.92.224:50002',
       'electrums://47.75.76.176:50002'
     ]
   },
   metaTokens: [],
 
   // Explorers:
-  addressExplorer: 'insight.zcoin.io/address/%s',
-  blockExplorer: 'insight.zcoin.io/block/%s',
-  transactionExplorer: 'insight.zcoin.io/tx/%s',
+  addressExplorer: 'https://insight.zcoin.io/address/%s',
+  blockExplorer: 'https://insight.zcoin.io/block/%s',
+  transactionExplorer: 'https://insight.zcoin.io/tx/%s',
 
   // Images:
   symbolImage:

--- a/src/plugin/serverCache.js
+++ b/src/plugin/serverCache.js
@@ -149,6 +149,10 @@ export class ServerCache {
       serverInfo.serverScore = MIN_SCORE
     }
 
+    if (serverInfo.numResponseTimes === 0) {
+      this.setResponseTime(serverUrl, 9999)
+    }
+
     console.log(
       `Stratum ${serverUrl} score went DOWN ${serverInfo.serverScore}`
     )


### PR DESCRIPTION
- Set the response time if serverScoreDown() is called. This prevents this server from being considered "new" and being tried again in the future at the top of the list.
- Fix port numbers for zcoin electrum servers
- Fix zcoin block explorer urls
- Completely ignore electrums: urls for now