### PR TITLE
currencyEngine: fix Android crash

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -285,6 +285,9 @@ export class CurrencyEngine {
         throw new Error('No io/fetch object')
       }
       await this.fetchFee()
+      if (!this.infoServer) {
+        throw new Error('infoServer not set')
+      }
       if (Date.now() - this.fees.timestamp > this.feeUpdateInterval) {
         const url = `${this.infoServer}/networkFees/${
           this.currencyInfo.currencyCode


### PR DESCRIPTION
An invalid URL crashes the app because an exception is not handled
on a much lower level. An URL can be invalid if for example
`infoServer` has not been set.

Relevant stacktrace:

> E AndroidRuntime: FATAL EXCEPTION: mqt_native_modules
E AndroidRuntime: Process: co.edgesecure.app, PID: 23930
E AndroidRuntime: java.lang.IllegalArgumentException: unexpected url: /networkFees/FTC
    E AndroidRuntime:     at okhttp3.Request$Builder.url(Request.java:142)