### PR TITLE
Do not try to fetch headers for heights < 0

### DIFF
--- a/src/engine/engineState.js
+++ b/src/engine/engineState.js
@@ -801,7 +801,7 @@ export class EngineState extends EventEmitter {
       // Fill up the missing headers to fetch
       for (const txid in this.txHeightCache) {
         const height = this.txHeightCache[txid].height
-        if (!this.pluginState.headerCache[`${height}`]) {
+        if (height > 0 && !this.pluginState.headerCache[`${height}`]) {
           this.missingHeaders[`${height}`] = true
         }
       }


### PR DESCRIPTION
Unconfirmed transactions have a height of -1 and querying for headers from block -1 causes failures on all servers that we access and causes infinite disconnect/reconnect.