### PR TITLE
Feathercoin: Activate SegWit

### DIFF
--- a/src/info/feathercoin.js
+++ b/src/info/feathercoin.js
@@ -11,7 +11,7 @@ export const feathercoinInfo: AbcCurrencyInfo = {
     { name: 'mFTC', multiplier: '100000', symbol: 'mF' }
   ],
   walletTypes: [
-    // 'wallet:feathercoin-bip49', // Disable creating segwit wallets for now
+    'wallet:feathercoin-bip49',
     'wallet:feathercoin-bip44',
     'wallet:feathercoin'
   ],


### PR DESCRIPTION
All Feathercoin ElectrumX servers now run Feathercoin 0.16 (based on Bitcoin Core 0.16) and therefore support SegWit now.

Have a nice week!