### PR TITLE
Move more functions into `formatSelector/coinUtils`

### DIFF
--- a/src/engine/currencyEngine.js
+++ b/src/engine/currencyEngine.js
@@ -659,14 +659,10 @@ export class CurrencyEngine {
 
   async signTx (edgeTransaction: EdgeTransaction): Promise<EdgeTransaction> {
     this.logEdgeTransaction(edgeTransaction, 'Signing')
-    const otherParams = edgeTransaction.otherParams
-    const { edgeSpendInfo, bcoinTx } = otherParams
+    const { edgeSpendInfo, bcoinTx } = edgeTransaction.otherParams || {}
     const { privateKeys = [] } = edgeSpendInfo
-    await this.keyManager.sign(bcoinTx, privateKeys)
-    edgeTransaction.date = Date.now() / MILLI_TO_SEC
-    edgeTransaction.signedTx = bcoinTx.toRaw().toString('hex')
-    edgeTransaction.txid = bcoinTx.rhash()
-    return edgeTransaction
+    const { signedTx, txid } = await this.keyManager.sign(bcoinTx, privateKeys)
+    return { ...edgeTransaction, signedTx, txid, date: Date.now() / MILLI_TO_SEC }
   }
 
   async broadcastTx (

--- a/src/utils/coinUtils.js
+++ b/src/utils/coinUtils.js
@@ -210,3 +210,8 @@ export const parsePath = (path: string = '', masterPath: string) =>
 
 export const sumUtxos = (utxos: Array<Utxo>) =>
   utxos.reduce((s, { tx, index }) => s + parseInt(tx.outputs[index].value), 0)
+
+export const seedFromEntropy = (entropy: Buffer) =>
+  hd.Mnemonic.fromEntropy(entropy).getPhrase()
+
+export const getLock = () => new utils.Lock()


### PR DESCRIPTION
Moved the following functions:
1. sign
2. getMasterKeys
3. keyFromSecret
4. deriveHdKey
5. seedFromEntropy
6. getLock
7. getXPubFromSeed

Another step in goal to abstract bcoin from the rest of the code