### PR TITLE
Tweak fees to improve confirmation times.

### DIFF
--- a/src/engine/miningFees.js
+++ b/src/engine/miningFees.js
@@ -14,8 +14,8 @@ export const ES_FEE_HIGH = 'high'
 export const ES_FEE_CUSTOM = 'custom'
 
 const MAX_FEE = 999999999.0
-const MAX_STANDARD_DELAY = 12
-const MIN_STANDARD_DELAY = 3
+const MAX_STANDARD_DELAY = 9
+const MIN_STANDARD_DELAY = 2
 
 /**
  * Calculate the BitcoinFees object given a default BitcoinFees object and EarnComFees
@@ -112,7 +112,7 @@ export function calcFeesFromEarnCom (
 
     // If we have a delay that's greater than MIN_STANDARD_DELAY, then we're done.
     // Otherwise we'd be getting bigger delays and further reducing fees.
-    if (fee.maxDelay > MIN_STANDARD_DELAY) {
+    if (fee.maxDelay >= MIN_STANDARD_DELAY) {
       break
     }
   }

--- a/test/engine/miningFees/miningFees.js
+++ b/test/engine/miningFees/miningFees.js
@@ -32,8 +32,8 @@ describe(`Mining Fees`, function () {
     assert.equal(outBitcoinFees.standardFeeLowAmount, '100000')
     assert.equal(outBitcoinFees.standardFeeHighAmount, '10000000')
     assert.equal(outBitcoinFees.lowFee, '10')
-    assert.equal(outBitcoinFees.standardFeeLow, '91')
-    assert.equal(outBitcoinFees.standardFeeHigh, '220')
+    assert.equal(outBitcoinFees.standardFeeLow, '101')
+    assert.equal(outBitcoinFees.standardFeeHigh, '280')
     assert.equal(outBitcoinFees.highFee, '300')
   })
   it('calcFeesFromEarnCom blank array', function () {


### PR DESCRIPTION
Change the standardFeeLow and high thresholds to between 2-8 blocks (instead of 3-12).
Also allow a fee estimate that returns maxDelay equal to or greater than 2 to be the standardLowFee. Use to require greater than.